### PR TITLE
Connect categorizador Python script via Express middleware

### DIFF
--- a/backend/middleware/pythonMiddleware.js
+++ b/backend/middleware/pythonMiddleware.js
@@ -1,0 +1,29 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+function runPython(req, res, next) {
+  const scriptPath = path.join(__dirname, '..', '..', 'categorizador', 'PWAT.py');
+  const python = spawn('python3', [scriptPath]);
+
+  let stdout = '';
+  let stderr = '';
+
+  python.stdout.on('data', data => {
+    stdout += data.toString();
+  });
+
+  python.stderr.on('data', data => {
+    stderr += data.toString();
+  });
+
+  python.on('close', code => {
+    if (code !== 0) {
+      req.pythonError = stderr || `Python process exited with code ${code}`;
+    } else {
+      req.pythonOutput = stdout.trim();
+    }
+    next();
+  });
+}
+
+module.exports = runPython;

--- a/backend/routes/pwatscore.routes.js
+++ b/backend/routes/pwatscore.routes.js
@@ -2,6 +2,7 @@
 const express = require("express");
 const router = express.Router();
 const controlador = require("../controllers/pwatscore.controller.js");
+const pythonMiddleware = require("../middleware/pythonMiddleware.js");
 
 // Rutas para pwatscore
 router.get("/", controlador.listarPwatscores);
@@ -9,5 +10,13 @@ router.post("/", controlador.crearPwatscore);
 router.post("/buscar", controlador.buscarPwatscore);
 router.put("/", controlador.actualizarPwatscore);
 router.delete("/", controlador.eliminarPwatscore);
+
+// Ejecutar el script de categorizador utilizando middleware
+router.get("/run-python", pythonMiddleware, (req, res) => {
+    if (req.pythonError) {
+        return res.status(500).json({ error: req.pythonError });
+    }
+    res.json({ output: req.pythonOutput });
+});
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- add middleware to execute `PWAT.py`
- expose a new `/run-python` route in pwatscore routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f85442d6c83308bb98f3e80426c79