### PR TITLE
Add basic Next.js frontend and login route

### DIFF
--- a/backend/middleware/token.middleware.js
+++ b/backend/middleware/token.middleware.js
@@ -5,7 +5,7 @@ const key = require('../config/const.js').JWT_SECRET;
 
 const tokenBlacklist = new Set();
 
-async function generateToken(usuario) {
+async function generarToken(usuario) {
   try {
     const token = await jwt.sign(
       {
@@ -78,7 +78,7 @@ function decode(token) {
 }
 
 module.exports = {
-    generateToken,
+    generarToken,
     blacklist,
     decode
 };

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -9,5 +9,6 @@ router.post("/crear", controlador.crearUser);
 router.post("/buscar", controlador.buscarUser);
 router.put("/", controlador.actualizarUser);
 router.delete("/", controlador.eliminarUser);
+router.post("/login", controlador.login);
 
 module.exports = router;

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+Este directorio contiene un ejemplo muy sencillo de una aplicaci\u00f3n Next.js. Primero se debe iniciar sesi\u00f3n en `http://localhost:8080/users/login` para obtener un token. Despu\u00e9s de autenticarse es posible ver los datos obtenidos desde el backend en la ruta `/consultas`.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  reactStrictMode: true,
+};

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/frontend/pages/_app.js
+++ b/frontend/pages/_app.js
@@ -1,0 +1,5 @@
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/frontend/pages/consultas.js
+++ b/frontend/pages/consultas.js
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Consultas() {
+  const router = useRouter();
+  const [datos, setDatos] = useState({});
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.replace('/login');
+      return;
+    }
+    const fetchData = async () => {
+      try {
+        const endpoints = ['pacientes', 'profesionales', 'imagenes', 'segmentaciones', 'pwatscore'];
+        const results = {};
+        for (const ep of endpoints) {
+          const res = await fetch(`http://localhost:8080/${ep}`, {
+            headers: { Authorization: `Bearer ${token}` }
+          });
+          results[ep] = await res.json();
+        }
+        setDatos(results);
+      } catch (err) {
+        setError('Error al obtener datos');
+      }
+    };
+    fetchData();
+  }, [router]);
+
+  return (
+    <div>
+      <h1>Consultas del backend</h1>
+      {error && <p style={{color:'red'}}>{error}</p>}
+      <pre>{JSON.stringify(datos, null, 2)}</pre>
+    </div>
+  );
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Home() {
+  const router = useRouter();
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.replace('/login');
+    }
+  }, [router]);
+
+  return (
+    <div>
+      <h1>Bienvenido</h1>
+      <p>
+        <a href="/consultas">Ir a consultas</a>
+      </p>
+    </div>
+  );
+}

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { useRouter } from 'next/router';
+
+export default function Login() {
+  const router = useRouter();
+  const [correo, setCorreo] = useState('');
+  const [contra, setContra] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('http://localhost:8080/users/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ correo, contra })
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.message || 'Error');
+      }
+      localStorage.setItem('token', data.token);
+      router.push('/consultas');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div>
+      <h1>Login</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Correo:</label>
+          <input value={correo} onChange={(e) => setCorreo(e.target.value)} />
+        </div>
+        <div>
+          <label>Contraseña:</label>
+          <input type="password" value={contra} onChange={(e) => setContra(e.target.value)} />
+        </div>
+        <button type="submit">Ingresar</button>
+      </form>
+      {error && <p style={{color:'red'}}>{error}</p>}
+    </div>
+  );
+}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,1 @@
+body { font-family: Arial, sans-serif; margin: 20px; }


### PR DESCRIPTION
## Summary
- add login route for users
- adjust token middleware export
- create a basic Next.js app under `frontend`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in `frontend` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684f8d249c848330890df339f6cf8fa1