### PR TITLE
Display operations list for each backend endpoint

### DIFF
--- a/frontend/pages/consultas/[tipo].js
+++ b/frontend/pages/consultas/[tipo].js
@@ -2,6 +2,45 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { BACKEND_URL } from '../../lib/api';
 
+const operaciones = {
+  pacientes: [
+    { metodo: 'GET', ruta: '/pacientes', descripcion: 'Listar pacientes' },
+    { metodo: 'POST', ruta: '/pacientes', descripcion: 'Crear paciente' },
+    { metodo: 'POST', ruta: '/pacientes/buscar', descripcion: 'Buscar paciente' },
+    { metodo: 'PUT', ruta: '/pacientes', descripcion: 'Actualizar paciente' },
+    { metodo: 'DELETE', ruta: '/pacientes', descripcion: 'Eliminar paciente' }
+  ],
+  profesionales: [
+    { metodo: 'GET', ruta: '/profesionales', descripcion: 'Listar profesionales' },
+    { metodo: 'POST', ruta: '/profesionales', descripcion: 'Crear profesional' },
+    { metodo: 'POST', ruta: '/profesionales/buscar', descripcion: 'Buscar profesional' },
+    { metodo: 'PUT', ruta: '/profesionales', descripcion: 'Actualizar profesional' },
+    { metodo: 'DELETE', ruta: '/profesionales', descripcion: 'Eliminar profesional' }
+  ],
+  imagenes: [
+    { metodo: 'GET', ruta: '/imagenes', descripcion: 'Listar imagenes' },
+    { metodo: 'POST', ruta: '/imagenes', descripcion: 'Crear imagen' },
+    { metodo: 'POST', ruta: '/imagenes/buscar', descripcion: 'Buscar imagen' },
+    { metodo: 'PUT', ruta: '/imagenes', descripcion: 'Actualizar imagen' },
+    { metodo: 'DELETE', ruta: '/imagenes', descripcion: 'Eliminar imagen' }
+  ],
+  segmentaciones: [
+    { metodo: 'GET', ruta: '/segmentaciones', descripcion: 'Listar segmentaciones' },
+    { metodo: 'POST', ruta: '/segmentaciones', descripcion: 'Crear segmentacion' },
+    { metodo: 'POST', ruta: '/segmentaciones/buscar', descripcion: 'Buscar segmentacion' },
+    { metodo: 'PUT', ruta: '/segmentaciones', descripcion: 'Actualizar segmentacion' },
+    { metodo: 'DELETE', ruta: '/segmentaciones', descripcion: 'Eliminar segmentacion' }
+  ],
+  pwatscore: [
+    { metodo: 'GET', ruta: '/pwatscore', descripcion: 'Listar pwatscore' },
+    { metodo: 'POST', ruta: '/pwatscore', descripcion: 'Crear pwatscore' },
+    { metodo: 'POST', ruta: '/pwatscore/buscar', descripcion: 'Buscar pwatscore' },
+    { metodo: 'PUT', ruta: '/pwatscore', descripcion: 'Actualizar pwatscore' },
+    { metodo: 'DELETE', ruta: '/pwatscore', descripcion: 'Eliminar pwatscore' },
+    { metodo: 'GET', ruta: '/pwatscore/run-python', descripcion: 'Ejecutar script de categorizador' }
+  ]
+};
+
 export default function ConsultaTipo() {
   const router = useRouter();
   const { tipo } = router.query;
@@ -35,6 +74,18 @@ export default function ConsultaTipo() {
   return (
     <div>
       <h1>{tipo}</h1>
+      {operaciones[tipo] && (
+        <>
+          <h2>Consultas disponibles</h2>
+          <ul>
+            {operaciones[tipo].map((op, idx) => (
+              <li key={idx}>
+                <code>{op.metodo} {op.ruta}</code> - {op.descripcion}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
       <pre>{JSON.stringify(data, null, 2)}</pre>
     </div>
   );


### PR DESCRIPTION
## Summary
- show all available API operations when inspecting an endpoint

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68501f1756688330b306e2557e88c1d5