### PR TITLE
Verify token on requests

### DIFF
--- a/backend/middleware/auth.middleware.js
+++ b/backend/middleware/auth.middleware.js
@@ -1,0 +1,21 @@
+const tokenfunc = require('./token.middleware.js');
+
+function verifyToken(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ message: 'Token requerido.' });
+  }
+  const parts = authHeader.split(' ');
+  if (parts.length !== 2 || parts[0] !== 'Bearer') {
+    return res.status(401).json({ message: 'Formato de token invalido.' });
+  }
+  const token = parts[1];
+  const decoded = tokenfunc.decode(token);
+  if (!decoded) {
+    return res.status(401).json({ message: 'Token invalido.' });
+  }
+  req.user = decoded;
+  next();
+}
+
+module.exports = verifyToken;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,10 +3,19 @@ const cors = require('cors');
 const app = express();
 const db = require("./models/index.js");
 const values = require("./config/const.js");
+const verifyToken = require('./middleware/auth.middleware.js');
 
 app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
+
+// Verificar token en todas las rutas excepto login y raiz
+app.use((req, res, next) => {
+  if (req.path === '/' || req.path === '/users/login') {
+    return next();
+  }
+  return verifyToken(req, res, next);
+});
 
 // Función para conectar a la base de datos con reintentos infinitos
 async function connectToDatabase() {

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,1 +1,12 @@
 export const BACKEND_URL = 'http://localhost:5000';
+
+export async function apiFetch(path, options = {}) {
+  const headers = options.headers || {};
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+  return fetch(`${BACKEND_URL}${path}`, { ...options, headers });
+}

--- a/frontend/pages/consultas/[tipo].js
+++ b/frontend/pages/consultas/[tipo].js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { BACKEND_URL } from '../../lib/api';
+import { BACKEND_URL, apiFetch } from '../../lib/api';
 
 const operaciones = {
   users: [
@@ -160,9 +160,7 @@ export default function ConsultaTipo() {
     if (!tipo) return;
     const fetchData = async () => {
       try {
-        const res = await fetch(`${BACKEND_URL}/${tipo}`, {
-          headers: { Authorization: `Bearer ${token}` }
-        });
+        const res = await apiFetch(`/${tipo}`);
         const json = await res.json();
         setData(json);
       } catch (err) {
@@ -173,17 +171,10 @@ export default function ConsultaTipo() {
   }, [router, tipo]);
 
   const ejecutarConsulta = async (op, body = null) => {
-    const token = localStorage.getItem('token');
-    if (!token) {
-      setError('Token no encontrado');
-      return;
-    }
-
     try {
       const opciones = {
         method: op.metodo,
         headers: {
-          Authorization: `Bearer ${token}`,
           'Content-Type': 'application/json'
         }
       };
@@ -192,7 +183,7 @@ export default function ConsultaTipo() {
         opciones.body = JSON.stringify(body);
       }
 
-      const res = await fetch(`${BACKEND_URL}${op.ruta}`, opciones);
+      const res = await apiFetch(op.ruta, opciones);
       const json = await res.json();
       setData(json);
       setError('');

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { BACKEND_URL } from '../lib/api';
+import { apiFetch } from '../lib/api';
 
 export default function Home() {
   const router = useRouter();
@@ -26,8 +26,7 @@ export default function Home() {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch(`${BACKEND_URL}/users/login`, {
-
+      const res = await apiFetch('/users/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ correo, contra })


### PR DESCRIPTION
## Summary
- implement auth middleware to validate JWT tokens
- enforce token validation for API routes in the server
- add `apiFetch` helper to automatically attach token headers in frontend
- use `apiFetch` in login and consult pages

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_e_6856ec1350608330a72adb20a1b38db3