### PR TITLE
Enable manual mask drawing with loading spinners

### DIFF
--- a/frontend/pages/pwatscore.js
+++ b/frontend/pages/pwatscore.js
@@ -13,6 +13,9 @@ export default function Pwatscore() {
   const [pwatscore, setPwatscore] = useState(null);
   const [error, setError] = useState('');
   const [maskOpacity, setMaskOpacity] = useState(0.5);
+  const [showCanvas, setShowCanvas] = useState(false);
+  const [loadingMask, setLoadingMask] = useState(false);
+  const [loadingPwatscore, setLoadingPwatscore] = useState(false);
 
 
   const canvasRef = useRef(null);
@@ -32,6 +35,8 @@ export default function Pwatscore() {
     setError('');
     setImagen(null);
     setMaskUrl(null);
+    setShowCanvas(false);
+    setSegmentacionId(null);
     setPwatscore(null);
     try {
       const res = await apiFetch('/imagenes/buscar', {
@@ -58,27 +63,46 @@ export default function Pwatscore() {
       if (!res.ok) throw new Error(json.message || 'Error');
       setSegmentacionId(json.segmentacionId);
       setMaskUrl(`${BACKEND_URL}/segmentaciones/${json.segmentacionId}/mask`);
+      setShowCanvas(true);
     } catch (err) {
       setError(err.message);
     }
   };
 
-  const handleAutomatico = async () => {
-    if (!imagen) return;
-    try {
-      const res = await apiFetch('/segmentaciones/automatico', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id: imagen.id })
-      });
-      const json = await res.json();
-      if (!res.ok) throw new Error(json.message || 'Error');
-      setSegmentacionId(json.segmentacionId);
-      setMaskUrl(`${BACKEND_URL}/segmentaciones/${json.segmentacionId}/mask`);
-    } catch (err) {
-      setError(err.message);
+  const handleNuevo = () => {
+    setSegmentacionId(null);
+    setMaskUrl(null);
+    setShowCanvas(true);
+    if (canvasRef.current) {
+      const canvas = canvasRef.current;
+      canvas.width = 256;
+      canvas.height = 256;
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = '#000000';
+      ctx.fillRect(0, 0, 256, 256);
     }
   };
+
+const handleAutomatico = async () => {
+  if (!imagen) return;
+  setLoadingMask(true);
+  try {
+    const res = await apiFetch('/segmentaciones/automatico', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: imagen.id })
+    });
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.message || 'Error');
+    setSegmentacionId(json.segmentacionId);
+    setMaskUrl(`${BACKEND_URL}/segmentaciones/${json.segmentacionId}/mask`);
+    setShowCanvas(true);
+  } catch (err) {
+    setError(err.message);
+  } finally {
+    setLoadingMask(false);
+  }
+};
 
   const startDraw = (e) => {
     setDrawing(true);
@@ -97,33 +121,48 @@ export default function Pwatscore() {
   };
 
   useEffect(() => {
-    if (!maskUrl || !canvasRef.current) return;
-    const img = new Image();
-    img.crossOrigin = 'anonymous';
-    img.src = maskUrl;
-    img.onload = () => {
-      const canvas = canvasRef.current;
-      canvas.width = 256;
-      canvas.height = 256;
-      const ctx = canvas.getContext('2d');
-      ctx.drawImage(img, 0, 0, 256, 256);
-
-    };
-  }, [maskUrl]);
+    if (!showCanvas || !canvasRef.current) return;
+    const canvas = canvasRef.current;
+    canvas.width = 256;
+    canvas.height = 256;
+    const ctx = canvas.getContext('2d');
+    if (maskUrl) {
+      const img = new Image();
+      img.crossOrigin = 'anonymous';
+      img.src = maskUrl;
+      img.onload = () => {
+        ctx.drawImage(img, 0, 0, 256, 256);
+      };
+    } else {
+      ctx.fillStyle = '#000000';
+      ctx.fillRect(0, 0, 256, 256);
+    }
+  }, [maskUrl, showCanvas]);
 
   const handleGuardarMascara = async () => {
-    if (!segmentacionId || !canvasRef.current) return;
+    if (!canvasRef.current) return;
     canvasRef.current.toBlob(async (blob) => {
       const formData = new FormData();
-      formData.append('id', segmentacionId);
       formData.append('imagen', new File([blob], 'mask.jpg', { type: 'image/jpg' }));
       try {
-        const res = await apiFetch('/segmentaciones/editar', { method: 'POST', body: formData });
-        const json = await res.json();
+        let res, json, id;
+        if (segmentacionId) {
+          formData.append('id', segmentacionId);
+          res = await apiFetch('/segmentaciones/editar', { method: 'POST', body: formData });
+          json = await res.json();
+          id = segmentacionId;
+        } else {
+          if (!imagen) return;
+          formData.append('id', imagen.id);
+          res = await apiFetch('/segmentaciones/manual', { method: 'POST', body: formData });
+          json = await res.json();
+          id = json.segmentacionId;
+          setSegmentacionId(id);
+        }
         if (!res.ok) throw new Error(json.message || 'Error');
         alert('Máscara guardada');
-        setMaskUrl(`${BACKEND_URL}/segmentaciones/${segmentacionId}/mask?${Date.now()}`);
-
+        setMaskUrl(`${BACKEND_URL}/segmentaciones/${id}/mask?${Date.now()}`);
+        setShowCanvas(true);
       } catch (err) {
         setError(err.message);
       }
@@ -134,6 +173,7 @@ export default function Pwatscore() {
     if (!imagen) return;
     setPwatscore(null);
     setError('');
+    setLoadingPwatscore(true);
     try {
       const res = await apiFetch('/pwatscore', {
         method: 'POST',
@@ -145,6 +185,8 @@ export default function Pwatscore() {
       setPwatscore({ id: json.pwatscoreId, ...json.categorias });
     } catch (err) {
       setError(err.message);
+    } finally {
+      setLoadingPwatscore(false);
     }
   };
 
@@ -182,7 +224,7 @@ export default function Pwatscore() {
               width={256}
               height={256}
             />
-            {maskUrl && (
+            {showCanvas && (
               <canvas
                 ref={canvasRef}
                 style={{position:'absolute', top:0, left:0, cursor:'crosshair', opacity: maskOpacity}}
@@ -199,8 +241,10 @@ export default function Pwatscore() {
             <input type="file" onChange={e => setMaskFile(e.target.files[0])} />
             <button onClick={handleManual}>Subir máscara</button>
             <button onClick={handleAutomatico}>Generar automática</button>
+            <button onClick={handleNuevo}>Dibujar máscara</button>
+            {loadingMask && <div className="spinner" style={{marginLeft:'0.5rem'}}></div>}
           </div>
-          {maskUrl && (
+          {showCanvas && (
             <div style={{marginTop:'1rem'}}>
               <label>Color: </label>
               <select value={drawColor} onChange={e => setDrawColor(e.target.value)}>
@@ -218,6 +262,7 @@ export default function Pwatscore() {
               />
               <button onClick={handleGuardarMascara} style={{marginLeft:'1rem'}}>Guardar máscara</button>
               <button onClick={handlePwatscore} style={{marginLeft:'0.5rem'}}>Calcular PWATScore</button>
+              {loadingPwatscore && <div className="spinner" style={{marginLeft:'0.5rem'}}></div>}
             </div>
           )}
 

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,1 +1,16 @@
 body { font-family: Arial, sans-serif; margin: 20px; }
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #555;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: spin 1s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
## Summary
- allow manual drawing of masks and creation if none exists
- show spinner animations while generating a mask and calculating PWATScore
- add CSS for the spinner component

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685911e24a188330a97078a74b769690