### PR TITLE
Add professional patient view and related API endpoints

### DIFF
--- a/backend/controllers/paciente.controller.js
+++ b/backend/controllers/paciente.controller.js
@@ -55,6 +55,41 @@ const buscarPaciente = async (req, res) => {
     }
 };
 
+const buscarPacienteRut = async (req, res) => {
+    const { rut } = req.body;
+    try {
+        const data = await db.Paciente.findOne({
+            where: { user_id: rut },
+            include: db.User
+        });
+        if (!data) {
+            return res.status(404).json({ message: "El paciente no existe." });
+        }
+        return res.status(200).json(data);
+    } catch (err) {
+        return res.status(500).json({
+            message: "Error al buscar paciente.",
+            err,
+        });
+    }
+};
+
+const listarPacientesProfesional = async (req, res) => {
+    const { profesionalId } = req.params;
+    try {
+        const data = await db.Paciente.findAll({
+            where: { profesional_id: profesionalId },
+            include: db.User
+        });
+        return res.status(200).json(data);
+    } catch (err) {
+        return res.status(500).json({
+            message: "Error al listar pacientes.",
+            err,
+        });
+    }
+};
+
 const actualizarPaciente = async (req, res) => {
     const { id, ...resto } = req.body;
     try {
@@ -91,6 +126,8 @@ module.exports = {
     listarPacientes,
     crearPaciente,
     buscarPaciente,
+    buscarPacienteRut,
+    listarPacientesProfesional,
     actualizarPaciente,
     eliminarPaciente
 };

--- a/backend/controllers/profesional.controller.js
+++ b/backend/controllers/profesional.controller.js
@@ -41,6 +41,22 @@ const buscarProfesional = async (req, res) => {
     }
 };
 
+const buscarProfesionalRut = async (req, res) => {
+    const { rut } = req.body;
+    try {
+        const data = await db.Profesional.findOne({ where: { user_id: rut } });
+        if (!data) {
+            return res.status(404).json({ message: "El profesional no existe." });
+        }
+        return res.status(200).json(data);
+    } catch (err) {
+        return res.status(500).json({
+            message: "Error al buscar profesional.",
+            err,
+        });
+    }
+};
+
 const actualizarProfesional = async (req, res) => {
     const { id, ...resto } = req.body;
     try {
@@ -77,6 +93,7 @@ module.exports = {
     listarProfesionales,
     crearProfesional,
     buscarProfesional,
+    buscarProfesionalRut,
     actualizarProfesional,
     eliminarProfesional
 };

--- a/backend/routes/imagen.routes.js
+++ b/backend/routes/imagen.routes.js
@@ -8,7 +8,9 @@ router.get("/", controlador.listarImagens);
 router.post("/", controlador.subirImagen);
 router.post("/buscar", controlador.buscarImagen);
 router.put("/", controlador.actualizarImagen);
+router.put("/:id/archivo", controlador.actualizarImagenArchivo);
 router.delete("/", controlador.eliminarImagen);
+router.get('/paciente/:pacienteId', controlador.listarImagenesPaciente);
 router.get('/:id/archivo', controlador.descargarImagen);
 
 module.exports = router;

--- a/backend/routes/paciente.routes.js
+++ b/backend/routes/paciente.routes.js
@@ -7,6 +7,8 @@ const controlador = require("../controllers/paciente.controller.js");
 router.get("/", controlador.listarPacientes);
 router.post("/", controlador.crearPaciente);
 router.post("/buscar", controlador.buscarPaciente);
+router.post("/buscar-rut", controlador.buscarPacienteRut);
+router.get("/profesional/:profesionalId", controlador.listarPacientesProfesional);
 router.put("/", controlador.actualizarPaciente);
 router.delete("/", controlador.eliminarPaciente);
 

--- a/backend/routes/profesional.routes.js
+++ b/backend/routes/profesional.routes.js
@@ -6,6 +6,7 @@ const controlador = require("../controllers/profesional.controller.js");
 router.get("/", controlador.listarProfesionales);
 router.post("/", controlador.crearProfesional);
 router.post("/buscar", controlador.buscarProfesional);
+router.post("/buscar-rut", controlador.buscarProfesionalRut);
 router.put("/", controlador.actualizarProfesional);
 router.delete("/", controlador.eliminarProfesional);
 

--- a/frontend/pages/profesional.js
+++ b/frontend/pages/profesional.js
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { apiFetch, BACKEND_URL } from '../lib/api';
+
+export default function ProfesionalPacientes() {
+  const router = useRouter();
+  const [pacientes, setPacientes] = useState([]);
+  const [filtro, setFiltro] = useState('');
+  const [seleccionado, setSeleccionado] = useState(null);
+  const [imagenes, setImagenes] = useState([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      router.replace('/');
+      return;
+    }
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    const rut = payload.rut;
+    async function load() {
+      try {
+        const resProf = await apiFetch('/profesionales/buscar-rut', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ rut })
+        });
+        const prof = await resProf.json();
+        if (!resProf.ok) throw new Error(prof.message || 'Error');
+        const resPacs = await apiFetch(`/pacientes/profesional/${prof.id}`);
+        const pacs = await resPacs.json();
+        setPacientes(pacs);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, [router]);
+
+  const seleccionar = async (p) => {
+    setSeleccionado(p);
+    const res = await apiFetch(`/imagenes/paciente/${p.id}`);
+    const imgs = await res.json();
+    setImagenes(imgs);
+  };
+
+  const subirImagen = async (e) => {
+    const file = e.target.files[0];
+    if (!file || !seleccionado) return;
+    const formData = new FormData();
+    formData.append('id', seleccionado.id);
+    formData.append('imagen', file);
+    const res = await apiFetch('/imagenes', { method: 'POST', body: formData });
+    const json = await res.json();
+    if (res.ok) {
+      setImagenes([...imagenes, json.imagen]);
+    }
+  };
+
+  const reemplazarImagen = async (imgId, file) => {
+    const formData = new FormData();
+    formData.append('imagen', file);
+    const res = await apiFetch(`/imagenes/${imgId}/archivo`, { method: 'PUT', body: formData });
+    const json = await res.json();
+    if (res.ok) {
+      setImagenes(imagenes.map(i => i.id === imgId ? json.imagen : i));
+    }
+  };
+
+  const filtrados = pacientes.filter(p =>
+    p.user && p.user.rut.toLowerCase().includes(filtro.toLowerCase())
+  );
+
+  return (
+    <div className="container">
+      <h1>Mis Pacientes</h1>
+      <div className="mt-1">
+        <input type="text" placeholder="Buscar por RUT" value={filtro} onChange={e => setFiltro(e.target.value)} />
+      </div>
+      <table className="mt-1" border="1" cellPadding="5">
+        <thead>
+          <tr>
+            <th>RUT</th>
+            <th>Nombre</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtrados.map(p => (
+            <tr key={p.id} onClick={() => seleccionar(p)} style={{cursor:'pointer'}}>
+              <td>{p.user?.rut}</td>
+              <td>{p.user?.nombre}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {seleccionado && (
+        <div className="mt-1">
+          <h2>Paciente: {seleccionado.user?.nombre}</h2>
+          <p><strong>RUT:</strong> {seleccionado.user?.rut}</p>
+          <p><strong>Sexo:</strong> {seleccionado.sexo}</p>
+          <p><strong>Ingreso:</strong> {seleccionado.fecha_ingreso}</p>
+          <p><strong>Comentarios:</strong> {seleccionado.comentarios}</p>
+
+          <div className="mt-1">
+            <input type="file" onChange={subirImagen} />
+          </div>
+          <div className="mt-1" style={{display:'flex', flexWrap:'wrap', gap:'1rem'}}>
+            {imagenes.map(img => (
+              <div key={img.id}>
+                <img src={`${BACKEND_URL}/imagenes/${img.id}/archivo`} alt="img" width={128} height={128} />
+                <input type="file" onChange={e => reemplazarImagen(img.id, e.target.files[0])} />
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- support fetching patients by professional and by RUT
- support listing a professional from a user RUT
- allow listing images by patient and updating an image file
- expose new API routes for these functions
- add `frontend/pages/profesional.js` with patient table and image management

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_685a97b8f9e4833099c5f6516da30273