### PR TITLE
Fix summary tense and clarify segmentation

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -60,13 +60,13 @@
 \beforepreface
 \prefacesection{Resumen}
 
-Las heridas ulcerosas en pacientes con pie diabético representaron una complicación clínica de alta prevalencia y riesgo, que afectó la calidad de vida de los pacientes y generó elevados costos sanitarios . Tradicionalmente, su evaluación dependió de criterios visuales subjetivos, lo que provocó variabilidad diagnóstica y retrasos en las decisiones terapéuticas; aunque se utilizó la escala PWAT (Photographic Wound Assessment Tool), esta aún presentaba limitaciones en objetividad y automatización .
+Las heridas ulcerosas en pacientes con pie diabético representan una complicación clínica de alta prevalencia y riesgo, que afecta la calidad de vida de los pacientes y genera elevados costos sanitarios. Tradicionalmente, su evaluación depende de criterios visuales subjetivos, lo que provoca variabilidad diagnóstica y retrasos en las decisiones terapéuticas; aunque se utiliza la escala PWAT (Photographic Wound Assessment Tool), esta aún presenta limitaciones en objetividad y automatización.
 
-Para abordar esta problemática, se desarrolló una herramienta automatizada que integró un modelo avanzado de segmentación semántica, extracción de características radiómicas mediante pyradiomics y algoritmos de machine learning, complementados con información clínica adicional para estimar objetivamente el puntaje PWAT .
+Para abordar esta problemática, se desarrolla una herramienta automatizada que integra un modelo avanzado de segmentación de imágenes\,\footnote{También denominada \emph{segmentación semántica}, consiste en clasificar cada píxel según la región que representa.}, extracción de características radiómicas mediante pyradiomics y algoritmos de \textit{machine learning}, complementados con información clínica adicional para estimar objetivamente el puntaje PWAT.
 
-Los resultados demostraron una mejora significativa en precisión y reproducibilidad frente a métodos manuales, posibilitando una evaluación integral del paciente y promoviendo intervenciones clínicas más oportunas y eficientes . De este modo, la metodología aportó robustez y escalabilidad al estado del arte en la valoración de heridas ulcerosas.
+Los resultados demuestran una mejora significativa en precisión y reproducibilidad frente a métodos manuales, posibilitando una evaluación integral del paciente y promoviendo intervenciones clínicas más oportunas y eficientes. De este modo, la metodología aporta robustez y escalabilidad al estado del arte en la valoración de heridas ulcerosas.
 
-En un contexto más amplio, la herramienta contribuyó a reducir complicaciones graves, optimizar la asignación de recursos sanitarios y mejorar la atención sanitaria general; a futuro, su implementación en aplicaciones móviles podría ampliar el acceso a evaluaciones remotas y generar alertas tempranas de deterioro.
+En un contexto más amplio, la herramienta contribuye a reducir complicaciones graves, optimizar la asignación de recursos sanitarios y mejorar la atención sanitaria general; a futuro, su implementación en aplicaciones móviles podría ampliar el acceso a evaluaciones remotas y generar alertas tempranas de deterioro.
 %A continuación aspectos que debe considera para escribir un resumen comprensible y que cumpla su %propósito.
 %
 %\begin{itemize}


### PR DESCRIPTION
## Summary
- keep page 2 abstract in present tense
- clarify semantic segmentation concept with a brief note

## Testing
- `pdflatex -interaction=nonstopmode -halt-on-error template.tex` *(fails: `adjustbox.sty` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869a20ddffc8330a526a3177be6893e